### PR TITLE
fix: update gitlab_variables to use the correct values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-02-18
+
+[Compare with previous version](https://github.com/sparkfabrik/terraform-google-gcp-gitlab-wif/compare/0.8.0...0.8.1)
+
+- Fix the output `gitlab_variables` to use consistent values.
+
 ## [0.8.0] - 2026-02-18
 
 [Compare with previous version](https://github.com/sparkfabrik/terraform-google-gcp-gitlab-wif/compare/0.7.0...0.8.0)

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,9 +23,9 @@ output "gitlab_variables" {
   description = "The GitLab variables created by this module."
   value = merge(
     {
-      (var.gitlab_gcp_wif_project_id_variable_name)            = var.gcp_project_id
-      (var.gitlab_gcp_wif_pool_variable_name)                  = google_iam_workload_identity_pool.this.name
-      (var.gitlab_gcp_wif_provider_variable_name)              = google_iam_workload_identity_pool_provider.this.name
+      (var.gitlab_gcp_wif_project_id_variable_name)            = data.google_project.project.number
+      (var.gitlab_gcp_wif_pool_variable_name)                  = google_iam_workload_identity_pool.this.workload_identity_pool_id
+      (var.gitlab_gcp_wif_provider_variable_name)              = google_iam_workload_identity_pool_provider.this.workload_identity_pool_provider_id
       (var.gitlab_gcp_wif_service_account_email_variable_name) = local.sa_email
     },
     length(var.gitlab_variables_additional) > 0 ? {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Updated `gitlab_variables` output to use correct resource attributes

- Changed project ID from `var.gcp_project_id` to `data.google_project.project.number`

- Replaced `.name` with full resource IDs for workload identity pool and provider

- Added changelog entry for version 0.8.1


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gitlab_variables output"] --> B["Project ID: var → data source"]
  A --> C["Pool: .name → .workload_identity_pool_id"]
  A --> D["Provider: .name → .workload_identity_pool_provider_id"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>outputs.tf</strong><dd><code>Fix gitlab_variables output to use correct resource attributes</code></dd></summary>
<hr>

outputs.tf

<ul><li>Changed project ID source from variable to data source number<br> <li> Updated workload identity pool to use full <code>workload_identity_pool_id</code> <br>attribute<br> <li> Updated provider to use full <code>workload_identity_pool_provider_id</code> <br>attribute</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-gcp-gitlab-wif/pull/18/files#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document version 0.8.1 release with output fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added version 0.8.1 release entry with date 2026-02-18<br> <li> Documented fix for <code>gitlab_variables</code> output consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-gcp-gitlab-wif/pull/18/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

