### PR TITLE
feat: add use_legacy_pool_provider_id_format variable for pre-1.0.0 ID layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ make generate-docs    # Lint + regenerate README.md (via terraform-docs)
 - **Markdown formatting.** After creating or editing any `.md` file, always run the formatter. Do not format markdown by hand.
 - **Examples** live in `examples/`. `examples/test.tfvars` is used by tflint and tfsec for validation.
 - **Renovate** manages dependency updates via `renovate.json` (extends SparkFabrik defaults).
+- **Provider version bumps.** Renovate handles routine bumps. Before manually bumping a provider in `versions.tf`, check the Terraform Registry for the latest stable release and any breaking changes in the release notes. Always commit the regenerated `.terraform.lock.hcl` together with the manifest change.
 
 ## Code Style
 
@@ -65,6 +66,7 @@ Keep the description lowercase, imperative, no period.
 
 - Always rebase onto `main` before pushing. No merge commits.
 - Use `--force-with-lease` (never `--force`) after rebasing.
+- Rebase before the first push, before opening a PR, and whenever `main` advances.
 
 ## CI/CD
 
@@ -72,6 +74,23 @@ The project uses GitHub Actions (`.github/workflows/tflint.yml`):
 
 - **Trigger:** push to `main` and pull request open/sync.
 - **Job:** `tflint` — runs tflint on the module to validate HCL.
+
+## OpenSpec Change Management
+
+Spec artifacts live in `openspec/changes/<name>/`, archived in `openspec/changes/archive/YYYY-MM-DD-<name>/`. Capabilities (long-lived specs) live in `openspec/specs/`. Configuration: `openspec/config.yaml`.
+
+### Git workflow for specs
+
+OpenSpec is a local file workflow. We add these conventions:
+
+1. **Always commit spec artifacts to git.** Never leave proposals, designs, specs, or tasks untracked. Commit them as soon as they are created or updated.
+2. **Non-trivial changes: spec-first PR.** For changes that span multiple files, involve architectural decisions, or require infrastructure work:
+   - Create a branch (e.g., `docs/<issue>-<name>-spec`).
+   - Commit the proposal, design, specs, and tasks.
+   - Open a PR for review ("is this the right plan?").
+   - Merge the spec PR before starting implementation.
+3. **Trivial changes: spec + implementation in one PR.** For small, well-scoped changes, spec and code can ship together.
+4. **Archive on merge.** When the implementation is complete, move `openspec/changes/<name>/` to `openspec/changes/archive/YYYY-MM-DD-<name>/` as part of that PR or an immediate follow-up. Do not leave completed changes in the active directory.
 
 ## Command Safety
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-27
+
+[Compare with previous version](https://github.com/sparkfabrik/terraform-google-gcp-gitlab-wif/compare/1.1.0...1.2.0)
+
 ### Added
 
 - Add `gitlab_user_logins` and `gitlab_user_ids` variables to restrict WIF authentication to specific GitLab users. `gitlab_user_logins` accepts usernames and resolves them to immutable numeric user IDs at plan time via the GitLab API (`data.gitlab_user`); `gitlab_user_ids` accepts numeric IDs directly for environments without GitLab API access. When both are set, the resulting ID set is the union. The WIF attribute condition matches on `attribute.user_id` (mapped from `assertion.user_id` by default), which is immutable, so this prevents access from being silently transferred if a username is renamed or freed and reclaimed by another user. A per-user `principalSet` (`attribute.user_id/<id>`) is emitted for each matching user, so the IAM binding self-documents the user gate.
 - Add `gitlab_user_filter_logic` variable controlling how the user filter combines with project/group filters: `and` (default) restricts authentication to tokens that match BOTH a source filter AND a user; `or` lets the listed users authenticate from any project/group (trusted-user bypass).
 - Add `attribute.user_id` (`assertion.user_id`) and `attribute.user_login` (`assertion.user_login`) to the default WIF provider attribute mapping.
+- Add `use_legacy_pool_provider_id_format` variable to opt back into the pre-1.0.0 pool and provider ID layout (`pool-{name}-{hex}`, `provider-{name}-{hex}`). Default remains the 1.0.0+ layout (`pool-{hex}-{name}`, `provider-{hex}-{name}`). This is intended as an escape hatch for deployments created before 1.0.0 that want to upgrade past 1.0.0 without destroying and recreating the pool, provider, IAM binding, and related GitLab CI/CD variables. See [UPGRADING.md](UPGRADING.md).
 
 ## [1.1.0] - 2026-05-26
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ You can refer to the official [GitLab documentation](https://docs.gitlab.com/ci/
 | <a name="input_name"></a> [name](#input_name)                                                                                                                                                    | The name to use for all resources created by this module.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | `string`                                                                                                                                                                                            | n/a                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |   yes    |
 | <a name="input_secret_gcp_project_id"></a> [secret_gcp_project_id](#input_secret_gcp_project_id)                                                                                                 | The GCP project ID where secrets will be created. If not provided, defaults to `var.gcp_project_id`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | `string`                                                                                                                                                                                            | `null`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |    no    |
 | <a name="input_secret_names"></a> [secret_names](#input_secret_names)                                                                                                                            | List of secret names to create and grant access to.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | `list(string)`                                                                                                                                                                                      | `[]`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |    no    |
+| <a name="input_use_legacy_pool_provider_id_format"></a> [use_legacy_pool_provider_id_format](#input_use_legacy_pool_provider_id_format)                                                          | If true, place the random hex suffix AFTER `var.name` in the workload identity pool and provider IDs (pre-1.0.0 layout: `pool-{name}-{hex}`, `provider-{name}-{hex}`). Default (false) uses the 1.0.0+ layout `pool-{hex}-{name}` / `provider-{hex}-{name}`, which avoids ID collisions when `var.name` is long enough to truncate the random part. Enable this ONLY to keep stability on existing deployments that were created before 1.0.0 and have not yet been migrated. Do not enable for new deployments.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | `bool`                                                                                                                                                                                              | `false`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |    no    |
 
 ## Outputs
 
@@ -97,3 +98,61 @@ You can refer to the official [GitLab documentation](https://docs.gitlab.com/ci/
 No modules.
 
 <!-- END_TF_DOCS -->
+
+## Recovering a deleted workload identity pool or provider
+
+Google Cloud **soft-deletes** workload identity pools and providers. When the resources managed by this module are destroyed (for example, by `terraform destroy`, or by a `terraform apply` that replaces them), they are not removed immediately. Instead:
+
+- Both pools and providers stay in a `DELETED` state for **up to 30 days**, after which the deletion becomes permanent ([source](https://cloud.google.com/iam/docs/manage-workload-identity-pools-providers)).
+- Deleting a pool also deletes all of its providers ("When you delete a workload identity pool, you also delete its workload identity pool providers." — [source](https://cloud.google.com/iam/docs/manage-workload-identity-pools-providers)).
+- While the resource is in the `DELETED` state, its ID **cannot be reused** to create a new pool or provider with the same name. From the docs: "Until a pool is permanently deleted, you cannot reuse its name when creating a new workload identity pool." The same restriction applies to providers.
+
+This matters in two situations:
+
+1. You destroyed the module by mistake and need to bring the same WIF back without changing GitLab CI/CD variables, IAM bindings on third-party resources, or the federation principal strings.
+2. You ran `terraform apply` after upgrading to 1.0.0+ without setting `use_legacy_pool_provider_id_format = true`, the old pool/provider were soft-deleted, and you want to roll back to the pre-1.0.0 layout (set the flag) without waiting 30 days for the IDs to be released.
+
+In both cases, the workflow is **undelete in Google Cloud, then import into Terraform state**. Do not let Terraform try to create a new resource with the same ID — it will fail until the soft-deleted one is purged.
+
+### Step 1: Undelete in Google Cloud
+
+Use `gcloud` (or the Cloud Console "Show deleted pools and providers" toggle described in the [official docs](https://cloud.google.com/iam/docs/manage-workload-identity-pools-providers)).
+
+Undelete the pool first ([gcloud reference](https://cloud.google.com/sdk/gcloud/reference/iam/workload-identity-pools/undelete)):
+
+```bash
+gcloud iam workload-identity-pools undelete POOL_ID \
+  --location=global \
+  --project=PROJECT_ID
+```
+
+Then undelete each provider ([gcloud reference](https://cloud.google.com/sdk/gcloud/reference/iam/workload-identity-pools/providers/undelete)):
+
+```bash
+gcloud iam workload-identity-pools providers undelete PROVIDER_ID \
+  --workload-identity-pool=POOL_ID \
+  --location=global \
+  --project=PROJECT_ID
+```
+
+`POOL_ID` and `PROVIDER_ID` are the short IDs (for example `pool-a1b2c3d4-myname`), not the full resource path. `LOCATION` is always `global` for the pools and providers created by this module.
+
+### Step 2: Import into Terraform state
+
+Once the resources are back to `ACTIVE`, import them into the module state so Terraform stops planning to recreate them. The exact addresses depend on whether the module is rooted at the top level or under a parent module (prefix with `module.<name>.` accordingly).
+
+Pool ([Terraform resource docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool#import)):
+
+```bash
+terraform import google_iam_workload_identity_pool.this \
+  projects/PROJECT_ID/locations/global/workloadIdentityPools/POOL_ID
+```
+
+Provider ([Terraform resource docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider#import)):
+
+```bash
+terraform import google_iam_workload_identity_pool_provider.this \
+  projects/PROJECT_ID/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID
+```
+
+After import, run `terraform plan` and verify that no replacement is queued. If Terraform still wants to replace the pool or provider, the `workload_identity_pool_id` / `workload_identity_pool_provider_id` computed by the module does not match the imported one; check `var.name`, the `random_id.suffix` value (`terraform state show random_id.suffix`), and `use_legacy_pool_provider_id_format`.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -29,3 +29,27 @@ All of these are configuration-only resources (no data is stored in them).
 1. Run `terraform plan` and verify that only the resources listed above are being replaced. The service account itself must **not** appear in the plan.
 2. Schedule a short maintenance window. GitLab CI/CD pipelines using WIF authentication will fail between the destroy and recreate (typically seconds).
 3. Run `terraform apply`.
+
+### Escape hatch: skipping the 1.0.0 rename
+
+Starting from 1.2.0, you can opt back into the pre-1.0.0 ID layout (`pool-{name}-{hex}`, `provider-{name}-{hex}`) by setting:
+
+```hcl
+use_legacy_pool_provider_id_format = true
+```
+
+With this flag set, upgrading from 0.9.x through 1.0.0+ does not replace the pool, provider, IAM binding, or related GitLab variables. Use this only when you need to defer the migration on existing deployments; new deployments should leave the flag at its default (`false`) to avoid the truncation/collision risk that motivated the 1.0.0 change.
+
+> **Strongly recommended:** treat this flag as a temporary bridge, not a permanent setting. Plan and schedule a migration to the new layout (`use_legacy_pool_provider_id_format = false`) as soon as a maintenance window allows. Keeping the legacy layout long-term leaves the deployment exposed to the ID truncation and collision risk that the 1.0.0 change was designed to eliminate. Once migrated, remove the flag from the module call so the default applies.
+
+### Recovering after an accidental upgrade
+
+If you already ran `terraform apply` against the 1.0.0+ layout and need to roll back to the legacy IDs (or simply restore a destroyed deployment), keep in mind that Google Cloud **soft-deletes** workload identity pools and providers for **up to 30 days** ([reference](https://cloud.google.com/iam/docs/manage-workload-identity-pools-providers)). During that window the deleted ID cannot be reused, so a plain `terraform apply` will fail.
+
+The recovery path is:
+
+1. `gcloud iam workload-identity-pools undelete POOL_ID --location=global --project=PROJECT_ID`
+2. `gcloud iam workload-identity-pools providers undelete PROVIDER_ID --workload-identity-pool=POOL_ID --location=global --project=PROJECT_ID`
+3. `terraform import` the pool and provider into the module state, then re-run `terraform plan` to confirm no replacement is queued.
+
+Full commands, address formats, and troubleshooting are in the ["Recovering a deleted workload identity pool or provider"](README.md#recovering-a-deleted-workload-identity-pool-or-provider) section of the README.

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,10 @@
 locals {
-  resource_name_suffix      = "${var.name}-${random_id.suffix.hex}"
-  resource_name_pool_suffix = "${random_id.suffix.hex}-${var.name}"
+  resource_name_suffix = "${var.name}-${random_id.suffix.hex}"
+  resource_name_pool_suffix = (
+    var.use_legacy_pool_provider_id_format
+    ? local.resource_name_suffix
+    : "${random_id.suffix.hex}-${var.name}"
+  )
 
   project_resource_suffix              = "project"
   group_resource_suffix                = "group"

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,12 @@ variable "gcp_service_account_project_id" {
   default     = null
 }
 
+variable "use_legacy_pool_provider_id_format" {
+  description = "If true, place the random hex suffix AFTER `var.name` in the workload identity pool and provider IDs (pre-1.0.0 layout: `pool-{name}-{hex}`, `provider-{name}-{hex}`). Default (false) uses the 1.0.0+ layout `pool-{hex}-{name}` / `provider-{hex}-{name}`, which avoids ID collisions when `var.name` is long enough to truncate the random part. Enable this ONLY to keep stability on existing deployments that were created before 1.0.0 and have not yet been migrated. Do not enable for new deployments."
+  type        = bool
+  default     = false
+}
+
 variable "gcp_workload_identity_pool_provider_attribute_mapping" {
   description = "A map of attribute mappings for the GCP Workload Identity Federation provider. This allows you to customize how attributes are mapped from GitLab to GCP."
   type        = map(string)


### PR DESCRIPTION
Add an opt-in bool variable that flips the workload identity pool and provider IDs back to the pre-1.0.0 layout (`pool-{name}-{hex}`, `provider-{name}-{hex}`). Default remains the 1.0.0+ layout (`pool-{hex}-{name}`, `provider-{hex}-{name}`).

This is an escape hatch for existing deployments that want to upgrade past 1.0.0 without destroying and recreating the pool, provider, IAM binding, and related GitLab CI/CD variables. New deployments should leave the flag at its default to avoid the truncation/collision risk that motivated the 1.0.0 change.

Assisted-by: claude-code/claude-opus-4-7